### PR TITLE
sync protobuf dependency with upstream, add `pip check`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/0006-Replace-google-protobuf-string-with-std-string.patch
 
 build:
-  number: 2
+  number: 3
   # VS 2008 is not supported for libprotobuf
   skip: true  # [win and py2k]
   script: python setup.py install --with-protobuf-include-dir=$PREFIX/include --with-protobuf-lib-dir=$PREFIX/lib --with-protoc=$BUILD_PREFIX/bin/protoc --with-mysql-capi=$PREFIX  # [unix]
@@ -43,7 +43,7 @@ requirements:
 
   run:
     - python
-    - protobuf >=3.0.0
+    - protobuf >=3.11.0,<=3.20.1
     - dnspython >=1.16.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,12 @@
-{% set name = "mysql-connector-python" %}
 {% set version = "8.0.31" %}
-{% set sha256 = "e6acf5ae9db404c714cf12d5588e074c8d30730a6054c873a8b9ff7641d464ec" %}
 
 package:
-  name: {{ name|lower }}
+  name: mysql-connector-python
   version: {{ version }}
 
 source:
   url: https://github.com/mysql/mysql-connector-python/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: e6acf5ae9db404c714cf12d5588e074c8d30730a6054c873a8b9ff7641d464ec
   patches:
     - patches/0001-Typecast-password-to-const-char-explicitly-py3.patch
     - patches/0002-Cast-uint-to-enum-mysql_enum_shutdown_level-explicit.patch
@@ -47,12 +45,15 @@ requirements:
     - dnspython >=1.16.0
 
 test:
+  requires:
+    - pip
   imports:
     - mysql
     - mysql.connector
     - mysqlx
     - mysqlx.protobuf
-
+  commands:
+    - pip check
 
 about:
   home: https://dev.mysql.com/doc/connector-python/en/


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- adds `pip check`
- syncs `protobuf` pin with upstream `setup.py`
  - caveat: i don't know what i don't know about protobuf compatibility
    - i thought the _whole idea_ was you'd only ever need a bottom pin :shrug: 
  - anyhow, observed in https://github.com/conda-forge/dagster-feedstock/pull/232 ([log](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=618935&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=13284)) 
    ```
    import: 'dagster_mysql'
    + pip check
    mysql-connector-python 8.0.30 has requirement protobuf<=3.20.1,>=3.11.0, but you have protobuf 3.20.2.
    ```
